### PR TITLE
chore: prepare v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,7 @@ checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -964,7 +964,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1181,7 +1181,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1605,7 +1605,7 @@ checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 [[package]]
 name = "libp2p"
 version = "0.52.1"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "bytes",
  "futures",
@@ -1635,7 +1635,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.2.0"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -1646,7 +1646,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.11.0"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "async-trait",
  "futures",
@@ -1664,7 +1664,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.2.0"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -1675,7 +1675,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.40.0"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "either",
  "fnv",
@@ -1702,7 +1702,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.40.0"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "async-std-resolver",
  "futures",
@@ -1717,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.43.0"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -1737,9 +1737,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2874d9c6575f1d7a151022af5c42bb0ffdcdfbafe0a6fd039de870b384835a2"
+version = "0.2.2"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -1757,7 +1756,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.44.2"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "arrayvec 0.7.4",
  "asynchronous-codec",
@@ -1784,7 +1783,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.44.0"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "async-io",
  "data-encoding",
@@ -1804,7 +1803,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.13.0"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "instant",
  "libp2p-core",
@@ -1821,7 +1820,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.43.0"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "bytes",
  "curve25519-dalek 3.2.0",
@@ -1845,7 +1844,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.43.0"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "either",
  "futures",
@@ -1862,7 +1861,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.8.0-alpha"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "async-std",
  "bytes",
@@ -1883,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.16.0"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -1906,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.25.0"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "async-trait",
  "futures",
@@ -1922,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-server"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-std",
  "base64 0.21.2",
@@ -1943,8 +1942,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.43.0"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+version = "0.43.1"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "async-std",
  "either",
@@ -1966,19 +1965,19 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.33.0"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "libp2p-tcp"
 version = "0.40.0"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "async-io",
  "futures",
@@ -1994,7 +1993,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.2.0"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -2012,7 +2011,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.44.0"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -2164,7 +2163,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "bytes",
  "futures",
@@ -2414,7 +2413,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -2535,7 +2534,7 @@ checksum = "70550716265d1ec349c41f70dd4f964b4fd88394efe4405f0c1da679c4799a07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -2588,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.2.0"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -2881,7 +2880,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/libp2p/rust-libp2p#b6b8844123644be602da6ea1f6c185493759ca5b"
+source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#7ff8be5fef889bcfc8974adc8f3bb94c919afff5"
 dependencies = [
  "futures",
  "pin-project",
@@ -2948,7 +2947,7 @@ checksum = "b69b106b68bc8054f0e974e70d19984040f8a5cf9215ca82626ea4853f82c4b9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -3323,9 +3322,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.23"
+version = "2.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3400,7 +3399,7 @@ checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -3554,7 +3553,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -3807,7 +3806,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
  "wasm-bindgen-shared",
 ]
 
@@ -3841,7 +3840,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4105,5 +4104,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-server"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Max Inden <mail@max-inden.de>"]
 edition = "2021"
 description = "A rust-libp2p server binary."
@@ -13,8 +13,8 @@ base64 = "0.21"
 env_logger = "0.10.0"
 futures = "0.3.27"
 futures-timer = "3"
-libp2p = { git = "https://github.com/libp2p/rust-libp2p", version = "0.52.0", default-features = false, features = ["autonat", "dns", "async-std", "noise", "tcp", "yamux", "identify", "kad", "ping", "relay", "metrics", "rsa", "macros"] }
-libp2p-quic = { git = "https://github.com/libp2p/rust-libp2p", version = "0.8.0-alpha", default-features = false, features = ["async-std"] }
+libp2p = { git = "https://github.com/mxinden/rust-libp2p", branch = "rsa-keypair-protobuf", version = "0.52.1", default-features = false, features = ["autonat", "dns", "async-std", "noise", "tcp", "yamux", "identify", "kad", "ping", "relay", "metrics", "rsa", "macros"] }
+libp2p-quic = { git = "https://github.com/mxinden/rust-libp2p", branch = "rsa-keypair-protobuf", version = "0.8.0-alpha", default-features = false, features = ["async-std"] }
 log = "0.4"
 prometheus-client = "0.21.0"
 serde = "1.0.167"
@@ -23,3 +23,8 @@ serde_json = "1.0"
 structopt = "0.3.26"
 tide = "0.16"
 zeroize = "1"
+
+[patch.crates-io]
+libp2p-identity = { git = "https://github.com/mxinden/rust-libp2p", branch = "rsa-keypair-protobuf" }
+
+


### PR DESCRIPTION
Prepare `rust-libp2p-server` `v0.12.0` based on https://github.com/libp2p/rust-libp2p/pull/4193.