### PR TITLE
fix(Cargo.toml): move back to libp2p master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,7 +453,7 @@ checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -964,7 +970,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -998,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "enum-as-inner"
@@ -1181,7 +1187,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1302,11 +1308,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 dependencies = [
  "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -1604,8 +1611,8 @@ checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "libp2p"
-version = "0.52.1"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+version = "0.52.2"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "bytes",
  "futures",
@@ -1635,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.2.0"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -1646,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.11.0"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "async-trait",
  "futures",
@@ -1664,7 +1671,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.2.0"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -1675,7 +1682,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.40.0"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "either",
  "fnv",
@@ -1702,7 +1709,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.40.0"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "async-std-resolver",
  "futures",
@@ -1717,7 +1724,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.43.0"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -1738,7 +1745,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identity"
 version = "0.2.2"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -1755,8 +1762,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.44.2"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+version = "0.44.3"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "arrayvec 0.7.4",
  "asynchronous-codec",
@@ -1783,7 +1790,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.44.0"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "async-io",
  "data-encoding",
@@ -1802,8 +1809,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.13.0"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+version = "0.13.1"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "instant",
  "libp2p-core",
@@ -1820,7 +1827,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.43.0"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "bytes",
  "curve25519-dalek 3.2.0",
@@ -1844,7 +1851,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.43.0"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "either",
  "futures",
@@ -1861,7 +1868,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.8.0-alpha"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "async-std",
  "bytes",
@@ -1881,8 +1888,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-relay"
-version = "0.16.0"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+version = "0.16.1"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -1904,8 +1911,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.25.0"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+version = "0.25.1"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "async-trait",
  "futures",
@@ -1943,7 +1950,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.43.1"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "async-std",
  "either",
@@ -1965,19 +1972,19 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.33.0"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]
 
 [[package]]
 name = "libp2p-tcp"
 version = "0.40.0"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "async-io",
  "futures",
@@ -1993,7 +2000,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.2.0"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -2011,7 +2018,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.44.0"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -2060,9 +2067,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718e8fae447df0c7e1ba7f5189829e63fd536945c8988d61444c19039f16b670"
+checksum = "eedb2bdbad7e0634f83989bf596f497b070130daaa398ab22d84c39e266deec5"
 dependencies = [
  "hashbrown",
 ]
@@ -2163,7 +2170,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "bytes",
  "futures",
@@ -2413,7 +2420,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -2534,7 +2541,7 @@ checksum = "70550716265d1ec349c41f70dd4f964b4fd88394efe4405f0c1da679c4799a07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -2587,7 +2594,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.2.0"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -2880,7 +2887,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/mxinden/rust-libp2p?branch=rsa-keypair-protobuf#377ac1da159e8cc04919d1d47f3cb4fdb50b5839"
+source = "git+https://github.com/libp2p/rust-libp2p#7f2ef013a878a3be0cff335fe377868da68a3e01"
 dependencies = [
  "futures",
  "pin-project",
@@ -2947,7 +2954,7 @@ checksum = "b23f7ade6f110613c0d63858ddb8b94c1041f550eab58a16b371bdf2c9c80ab4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -3322,9 +3329,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.25"
+version = "2.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3384,22 +3391,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -3553,7 +3560,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -3806,7 +3813,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
  "wasm-bindgen-shared",
 ]
 
@@ -3840,7 +3847,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4104,5 +4111,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.27",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ base64 = "0.21"
 env_logger = "0.10.0"
 futures = "0.3.27"
 futures-timer = "3"
-libp2p = { git = "https://github.com/mxinden/rust-libp2p", branch = "rsa-keypair-protobuf", version = "0.52.1", default-features = false, features = ["autonat", "dns", "async-std", "noise", "tcp", "yamux", "identify", "kad", "ping", "relay", "metrics", "rsa", "macros"] }
-libp2p-quic = { git = "https://github.com/mxinden/rust-libp2p", branch = "rsa-keypair-protobuf", version = "0.8.0-alpha", default-features = false, features = ["async-std"] }
+libp2p = { git = "https://github.com/libp2p/rust-libp2p", version = "0.52.1", default-features = false, features = ["autonat", "dns", "async-std", "noise", "tcp", "yamux", "identify", "kad", "ping", "relay", "metrics", "rsa", "macros"] }
+libp2p-quic = { git = "https://github.com/libp2p/rust-libp2p", version = "0.8.0-alpha", default-features = false, features = ["async-std"] }
 log = "0.4"
 prometheus-client = "0.21.2"
 serde = "1.0.175"
@@ -25,6 +25,4 @@ tide = "0.16"
 zeroize = "1"
 
 [patch.crates-io]
-libp2p-identity = { git = "https://github.com/mxinden/rust-libp2p", branch = "rsa-keypair-protobuf" }
-
-
+libp2p-identity = { git = "https://github.com/libp2p/rust-libp2p" }


### PR DESCRIPTION
With https://github.com/libp2p/rust-libp2p/pull/4193 merged, we no longer need to depend on mxinden fork.