### PR TITLE
chore(Cargo.toml): update to latest libp2p master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,7 +1612,7 @@ checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 [[package]]
 name = "libp2p"
 version = "0.52.2"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "bytes",
  "futures",
@@ -1642,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.2.0"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "libp2p-autonat"
 version = "0.11.0"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "async-trait",
  "futures",
@@ -1670,8 +1670,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.2.0"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+version = "0.2.1"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -1682,7 +1682,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.40.0"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "either",
  "fnv",
@@ -1709,7 +1709,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.40.0"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "async-std-resolver",
  "futures",
@@ -1724,7 +1724,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.43.0"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -1745,7 +1745,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identity"
 version = "0.2.2"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -1763,7 +1763,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.44.3"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "arrayvec 0.7.4",
  "asynchronous-codec",
@@ -1790,7 +1790,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.44.0"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "async-io",
  "data-encoding",
@@ -1810,7 +1810,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.13.1"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "instant",
  "libp2p-core",
@@ -1827,7 +1827,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.43.0"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "bytes",
  "curve25519-dalek 3.2.0",
@@ -1851,7 +1851,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.43.0"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "either",
  "futures",
@@ -1867,8 +1867,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.8.0-alpha"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+version = "0.9.0-alpha"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "async-std",
  "bytes",
@@ -1880,7 +1880,7 @@ dependencies = [
  "libp2p-tls",
  "log",
  "parking_lot",
- "quinn-proto",
+ "quinn",
  "rand 0.8.5",
  "rustls",
  "thiserror",
@@ -1889,7 +1889,7 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.16.1"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -1912,7 +1912,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.25.1"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "async-trait",
  "futures",
@@ -1950,7 +1950,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.43.2"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "async-std",
  "either",
@@ -1972,7 +1972,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.33.0"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-warning",
@@ -1984,7 +1984,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.40.0"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "async-io",
  "futures",
@@ -2000,7 +2000,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.2.0"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -2018,7 +2018,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.44.0"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -2170,7 +2170,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "bytes",
  "futures",
@@ -2594,13 +2594,33 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.2.0"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "asynchronous-codec",
  "bytes",
  "quick-protobuf",
  "thiserror",
  "unsigned-varint",
+]
+
+[[package]]
+name = "quinn"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21252f1c0fc131f1b69182db8f34837e8a69737b8251dff75636a9be0518c324"
+dependencies = [
+ "async-io",
+ "async-std",
+ "bytes",
+ "futures-io",
+ "pin-project-lite 0.2.10",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "thiserror",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2618,6 +2638,19 @@ dependencies = [
  "thiserror",
  "tinyvec",
  "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6df19e284d93757a9fb91d63672f7741b129246a669db09d1c0063071debc0c0"
+dependencies = [
+ "bytes",
+ "libc",
+ "socket2 0.5.3",
+ "tracing",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2887,7 +2920,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/libp2p/rust-libp2p#da743ec4868d128313ea026a776d40086f7941e7"
+source = "git+https://github.com/libp2p/rust-libp2p#6d3015a4aa41b539ccc91c7caea7c9f9dfc8042c"
 dependencies = [
  "futures",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ env_logger = "0.10.0"
 futures = "0.3.27"
 futures-timer = "3"
 libp2p = { git = "https://github.com/libp2p/rust-libp2p", version = "0.52.1", default-features = false, features = ["autonat", "dns", "async-std", "noise", "tcp", "yamux", "identify", "kad", "ping", "relay", "metrics", "rsa", "macros"] }
-libp2p-quic = { git = "https://github.com/libp2p/rust-libp2p", version = "0.8.0-alpha", default-features = false, features = ["async-std"] }
+libp2p-quic = { git = "https://github.com/libp2p/rust-libp2p", version = "0.9.0-alpha", default-features = false, features = ["async-std"] }
 log = "0.4"
 prometheus-client = "0.21.2"
 serde = "1.0.177"


### PR DESCRIPTION
Most prominently, includes https://github.com/libp2p/rust-libp2p/pull/3454.